### PR TITLE
捕获异步保存失败的异常，以免后续任务停止执行

### DIFF
--- a/call-statistics-jdbc/src/main/java/org/kaws/autoconfigure/MongoCallStatisticsAutoConfiguration.java
+++ b/call-statistics-jdbc/src/main/java/org/kaws/autoconfigure/MongoCallStatisticsAutoConfiguration.java
@@ -111,11 +111,11 @@ public class MongoCallStatisticsAutoConfiguration implements ApplicationContextA
 
         scheduledThreadPoolExecutor.scheduleWithFixedDelay(() -> {
             if (!CollectionUtils.isEmpty(mongoCallRecords)) {
-                MongoCallRecordBiz mongoCallRecordBiz = applicationContext.getBean(MongoCallRecordBiz.class);
-
-                ArrayList<MongoCallRecord> savingCallRecords;
-                lock.lock();
                 try {
+                    MongoCallRecordBiz mongoCallRecordBiz = applicationContext.getBean(MongoCallRecordBiz.class);
+
+                    ArrayList<MongoCallRecord> savingCallRecords;
+                    lock.lock();
                     savingCallRecords = Lists.newArrayList(mongoCallRecords);
                     mongoCallRecords.clear();
                     mongoCallRecordBiz.saveCallRecords(savingCallRecords);
@@ -123,18 +123,17 @@ public class MongoCallStatisticsAutoConfiguration implements ApplicationContextA
                         log.debug("Mongo Has Saved CallRecords:{} Successfully", savingCallRecords.size());
                     }
                 } catch (Exception e) {
-                    e.printStackTrace();
-                    log.error("Mongo save failed");
+                    log.error("Mongo save failed：{} ", e.getMessage());
                 } finally {
                     lock.unlock();
                 }
 
             }
             if (!CollectionUtils.isEmpty(mongoCallSuccessRecords)) {
-                MongoCallRecordBiz mongoCallRecordBiz = applicationContext.getBean(MongoCallRecordBiz.class);
-                ArrayList<MongoCallSuccessRecord> savingCallRecords;
-                lock.lock();
                 try {
+                    MongoCallRecordBiz mongoCallRecordBiz = applicationContext.getBean(MongoCallRecordBiz.class);
+                    ArrayList<MongoCallSuccessRecord> savingCallRecords;
+                    lock.lock();
                     savingCallRecords = Lists.newArrayList(mongoCallSuccessRecords);
                     mongoCallSuccessRecords.clear();
                     mongoCallRecordBiz.saveCallSuccessRecords(savingCallRecords);
@@ -142,8 +141,7 @@ public class MongoCallStatisticsAutoConfiguration implements ApplicationContextA
                         log.debug("Mongo Has Saved CallSuccessRecords:{} Successfully", savingCallRecords.size());
                     }
                 } catch (Exception e) {
-                    e.printStackTrace();
-                    log.error("Mongo save failed ");
+                    log.error("Mongo save failed：{} ", e.getMessage());
                 } finally {
                     lock.unlock();
                 }

--- a/call-statistics-jdbc/src/main/java/org/kaws/autoconfigure/MongoCallStatisticsAutoConfiguration.java
+++ b/call-statistics-jdbc/src/main/java/org/kaws/autoconfigure/MongoCallStatisticsAutoConfiguration.java
@@ -118,13 +118,17 @@ public class MongoCallStatisticsAutoConfiguration implements ApplicationContextA
                 try {
                     savingCallRecords = Lists.newArrayList(mongoCallRecords);
                     mongoCallRecords.clear();
+                    mongoCallRecordBiz.saveCallRecords(savingCallRecords);
+                    if (log.isDebugEnabled()) {
+                        log.debug("Mongo Has Saved CallRecords:{} Successfully", savingCallRecords.size());
+                    }
+                } catch (Exception e) {
+                    e.printStackTrace();
+                    log.error("Mongo save failed");
                 } finally {
                     lock.unlock();
                 }
-                mongoCallRecordBiz.saveCallRecords(savingCallRecords);
-                if (log.isDebugEnabled()) {
-                    log.debug("Mongo Has Saved CallRecords:{} Successfully", savingCallRecords.size());
-                }
+
             }
             if (!CollectionUtils.isEmpty(mongoCallSuccessRecords)) {
                 MongoCallRecordBiz mongoCallRecordBiz = applicationContext.getBean(MongoCallRecordBiz.class);
@@ -133,13 +137,17 @@ public class MongoCallStatisticsAutoConfiguration implements ApplicationContextA
                 try {
                     savingCallRecords = Lists.newArrayList(mongoCallSuccessRecords);
                     mongoCallSuccessRecords.clear();
+                    mongoCallRecordBiz.saveCallSuccessRecords(savingCallRecords);
+                    if (log.isDebugEnabled()) {
+                        log.debug("Mongo Has Saved CallSuccessRecords:{} Successfully", savingCallRecords.size());
+                    }
+                } catch (Exception e) {
+                    e.printStackTrace();
+                    log.error("Mongo save failed ");
                 } finally {
                     lock.unlock();
                 }
-                mongoCallRecordBiz.saveCallSuccessRecords(savingCallRecords);
-                if (log.isDebugEnabled()) {
-                    log.debug("Mongo Has Saved CallSuccessRecords:{} Successfully", savingCallRecords.size());
-                }
+
             }
         }, 60, 10, TimeUnit.SECONDS);
 

--- a/call-statistics-jdbc/src/main/java/org/kaws/autoconfigure/MySQLCallStatisticsAutoConfiguration.java
+++ b/call-statistics-jdbc/src/main/java/org/kaws/autoconfigure/MySQLCallStatisticsAutoConfiguration.java
@@ -89,12 +89,15 @@ public class MySQLCallStatisticsAutoConfiguration implements ApplicationContextA
                 try {
                     savingCallRecords = Lists.newArrayList(mySQLCallRecords);
                     mySQLCallRecords.clear();
+                    mySQLCallRecordBiz.saveCallRecords(savingCallRecords);
+                    if (log.isDebugEnabled()) {
+                        log.debug("MySQL Has Saved CallRecords:{} Successfully", savingCallRecords.size());
+                    }
+                } catch (Exception e) {
+                    e.printStackTrace();
+                    log.error("Mongo save failed ");
                 } finally {
                     lock.unlock();
-                }
-                mySQLCallRecordBiz.saveCallRecords(savingCallRecords);
-                if (log.isDebugEnabled()) {
-                    log.debug("MySQL Has Saved CallRecords:{} Successfully", savingCallRecords.size());
                 }
             }
             if (!CollectionUtils.isEmpty(mySQLCallSuccessRecords)) {
@@ -104,12 +107,15 @@ public class MySQLCallStatisticsAutoConfiguration implements ApplicationContextA
                 try {
                     savingCallRecords = Lists.newArrayList(mySQLCallSuccessRecords);
                     mySQLCallSuccessRecords.clear();
+                    mySQLCallRecordBiz.saveCallSuccessRecords(savingCallRecords);
+                    if (log.isDebugEnabled()) {
+                        log.debug("MySQL Has Saved CallSuccessRecords:{} Successfully", savingCallRecords.size());
+                    }
+                } catch (Exception e) {
+                    e.printStackTrace();
+                    log.error("Mongo save failed ");
                 } finally {
                     lock.unlock();
-                }
-                mySQLCallRecordBiz.saveCallSuccessRecords(savingCallRecords);
-                if (log.isDebugEnabled()) {
-                    log.debug("MySQL Has Saved CallSuccessRecords:{} Successfully", savingCallRecords.size());
                 }
             }
         }, 60, 10, TimeUnit.SECONDS);

--- a/call-statistics-jdbc/src/main/java/org/kaws/autoconfigure/MySQLCallStatisticsAutoConfiguration.java
+++ b/call-statistics-jdbc/src/main/java/org/kaws/autoconfigure/MySQLCallStatisticsAutoConfiguration.java
@@ -83,10 +83,10 @@ public class MySQLCallStatisticsAutoConfiguration implements ApplicationContextA
 
         scheduledThreadPoolExecutor.scheduleWithFixedDelay(() -> {
             if (!CollectionUtils.isEmpty(mySQLCallRecords)) {
-                MySQLCallRecordBiz mySQLCallRecordBiz = applicationContext.getBean(MySQLCallRecordBiz.class);
-                ArrayList<MySQLCallRecord> savingCallRecords;
-                lock.lock();
                 try {
+                    MySQLCallRecordBiz mySQLCallRecordBiz = applicationContext.getBean(MySQLCallRecordBiz.class);
+                    ArrayList<MySQLCallRecord> savingCallRecords;
+                    lock.lock();
                     savingCallRecords = Lists.newArrayList(mySQLCallRecords);
                     mySQLCallRecords.clear();
                     mySQLCallRecordBiz.saveCallRecords(savingCallRecords);
@@ -94,17 +94,16 @@ public class MySQLCallStatisticsAutoConfiguration implements ApplicationContextA
                         log.debug("MySQL Has Saved CallRecords:{} Successfully", savingCallRecords.size());
                     }
                 } catch (Exception e) {
-                    e.printStackTrace();
-                    log.error("Mongo save failed ");
+                    log.error("Mongo save failed：{} ", e.getMessage());
                 } finally {
                     lock.unlock();
                 }
             }
             if (!CollectionUtils.isEmpty(mySQLCallSuccessRecords)) {
-                MySQLCallRecordBiz mySQLCallRecordBiz = applicationContext.getBean(MySQLCallRecordBiz.class);
-                ArrayList<MySQLCallSuccessRecord> savingCallRecords;
-                lock.lock();
                 try {
+                    MySQLCallRecordBiz mySQLCallRecordBiz = applicationContext.getBean(MySQLCallRecordBiz.class);
+                    ArrayList<MySQLCallSuccessRecord> savingCallRecords;
+                    lock.lock();
                     savingCallRecords = Lists.newArrayList(mySQLCallSuccessRecords);
                     mySQLCallSuccessRecords.clear();
                     mySQLCallRecordBiz.saveCallSuccessRecords(savingCallRecords);
@@ -112,8 +111,7 @@ public class MySQLCallStatisticsAutoConfiguration implements ApplicationContextA
                         log.debug("MySQL Has Saved CallSuccessRecords:{} Successfully", savingCallRecords.size());
                     }
                 } catch (Exception e) {
-                    e.printStackTrace();
-                    log.error("Mongo save failed ");
+                    log.error("Mongo save failed：{} ", e.getMessage());
                 } finally {
                     lock.unlock();
                 }

--- a/call-statistics-jpa/src/main/java/org/kaws/autoconfigure/MongoCallStatisticsAutoConfiguration.java
+++ b/call-statistics-jpa/src/main/java/org/kaws/autoconfigure/MongoCallStatisticsAutoConfiguration.java
@@ -111,11 +111,10 @@ public class MongoCallStatisticsAutoConfiguration implements ApplicationContextA
 
         scheduledThreadPoolExecutor.scheduleAtFixedRate(() -> {
             if (!CollectionUtils.isEmpty(mongoCallRecords)) {
-                MongoCallRecordBiz mongoCallRecordBiz = applicationContext.getBean(MongoCallRecordBiz.class);
-
-                ArrayList<MongoCallRecord> savingCallRecords;
-                lock.lock();
                 try {
+                    MongoCallRecordBiz mongoCallRecordBiz = applicationContext.getBean(MongoCallRecordBiz.class);
+                    ArrayList<MongoCallRecord> savingCallRecords;
+                    lock.lock();
                     savingCallRecords = Lists.newArrayList(mongoCallRecords);
                     mongoCallRecords.clear();
                     mongoCallRecordBiz.saveCallRecords(savingCallRecords);
@@ -123,17 +122,16 @@ public class MongoCallStatisticsAutoConfiguration implements ApplicationContextA
                         log.debug("Mongo Has Saved CallRecords:{} Successfully", savingCallRecords.size());
                     }
                 } catch (Exception e) {
-                    e.printStackTrace();
-                    log.error("Mongo save failed ");
+                    log.error("Mongo save failed：{} ", e.getMessage());
                 } finally {
                     lock.unlock();
                 }
             }
             if (!CollectionUtils.isEmpty(mongoCallSuccessRecords)) {
-                MongoCallRecordBiz mongoCallRecordBiz = applicationContext.getBean(MongoCallRecordBiz.class);
-                ArrayList<MongoCallSuccessRecord> savingCallRecords;
-                lock.lock();
                 try {
+                    MongoCallRecordBiz mongoCallRecordBiz = applicationContext.getBean(MongoCallRecordBiz.class);
+                    ArrayList<MongoCallSuccessRecord> savingCallRecords;
+                    lock.lock();
                     savingCallRecords = Lists.newArrayList(mongoCallSuccessRecords);
                     mongoCallSuccessRecords.clear();
                     mongoCallRecordBiz.saveCallSuccessRecords(savingCallRecords);
@@ -141,8 +139,7 @@ public class MongoCallStatisticsAutoConfiguration implements ApplicationContextA
                         log.debug("Mongo Has Saved CallSuccessRecords:{} Successfully", savingCallRecords.size());
                     }
                 } catch (Exception e) {
-                    e.printStackTrace();
-                    log.error("Mongo save failed ");
+                    log.error("Mongo save failed：{} ", e.getMessage());
                 } finally {
                     lock.unlock();
                 }

--- a/call-statistics-jpa/src/main/java/org/kaws/autoconfigure/MongoCallStatisticsAutoConfiguration.java
+++ b/call-statistics-jpa/src/main/java/org/kaws/autoconfigure/MongoCallStatisticsAutoConfiguration.java
@@ -118,12 +118,15 @@ public class MongoCallStatisticsAutoConfiguration implements ApplicationContextA
                 try {
                     savingCallRecords = Lists.newArrayList(mongoCallRecords);
                     mongoCallRecords.clear();
+                    mongoCallRecordBiz.saveCallRecords(savingCallRecords);
+                    if (log.isDebugEnabled()) {
+                        log.debug("Mongo Has Saved CallRecords:{} Successfully", savingCallRecords.size());
+                    }
+                } catch (Exception e) {
+                    e.printStackTrace();
+                    log.error("Mongo save failed ");
                 } finally {
                     lock.unlock();
-                }
-                mongoCallRecordBiz.saveCallRecords(savingCallRecords);
-                if (log.isDebugEnabled()) {
-                    log.debug("Mongo Has Saved CallRecords:{} Successfully", savingCallRecords.size());
                 }
             }
             if (!CollectionUtils.isEmpty(mongoCallSuccessRecords)) {
@@ -133,12 +136,15 @@ public class MongoCallStatisticsAutoConfiguration implements ApplicationContextA
                 try {
                     savingCallRecords = Lists.newArrayList(mongoCallSuccessRecords);
                     mongoCallSuccessRecords.clear();
+                    mongoCallRecordBiz.saveCallSuccessRecords(savingCallRecords);
+                    if (log.isDebugEnabled()) {
+                        log.debug("Mongo Has Saved CallSuccessRecords:{} Successfully", savingCallRecords.size());
+                    }
+                } catch (Exception e) {
+                    e.printStackTrace();
+                    log.error("Mongo save failed ");
                 } finally {
                     lock.unlock();
-                }
-                mongoCallRecordBiz.saveCallSuccessRecords(savingCallRecords);
-                if (log.isDebugEnabled()) {
-                    log.debug("Mongo Has Saved CallSuccessRecords:{} Successfully", savingCallRecords.size());
                 }
             }
         }, 60, 10, TimeUnit.SECONDS);

--- a/call-statistics-jpa/src/main/java/org/kaws/autoconfigure/MySQLCallStatisticsAutoConfiguration.java
+++ b/call-statistics-jpa/src/main/java/org/kaws/autoconfigure/MySQLCallStatisticsAutoConfiguration.java
@@ -61,9 +61,9 @@ public class MySQLCallStatisticsAutoConfiguration implements ApplicationContextA
     }
 
 
-	/**
-	 * 缓存调用记录，用于异步刷库
-	 */
+    /**
+     * 缓存调用记录，用于异步刷库
+     */
     @Bean
     public List<MySQLCallRecord> mySQLCallRecords() {
         return new ArrayList<>();
@@ -92,12 +92,15 @@ public class MySQLCallStatisticsAutoConfiguration implements ApplicationContextA
                 try {
                     savingCallRecords = Lists.newArrayList(mySQLCallRecords);
                     mySQLCallRecords.clear();
+                    mySQLCallRecordBiz.saveCallRecords(savingCallRecords);
+                    if (log.isDebugEnabled()) {
+                        log.debug("MySQL Has Saved CallRecords:{} Successfully", savingCallRecords.size());
+                    }
+                } catch (Exception e) {
+                    e.printStackTrace();
+                    log.error("Mongo save failed ");
                 } finally {
                     lock.unlock();
-                }
-                mySQLCallRecordBiz.saveCallRecords(savingCallRecords);
-                if (log.isDebugEnabled()) {
-                    log.debug("MySQL Has Saved CallRecords:{} Successfully", savingCallRecords.size());
                 }
             }
             if (!CollectionUtils.isEmpty(mySQLCallSuccessRecords)) {
@@ -107,12 +110,15 @@ public class MySQLCallStatisticsAutoConfiguration implements ApplicationContextA
                 try {
                     savingCallRecords = Lists.newArrayList(mySQLCallSuccessRecords);
                     mySQLCallSuccessRecords.clear();
+                    mySQLCallRecordBiz.saveCallSuccessRecords(savingCallRecords);
+                    if (log.isDebugEnabled()) {
+                        log.debug("MySQL Has Saved CallSuccessRecords:{} Successfully", savingCallRecords.size());
+                    }
+                } catch (Exception e) {
+                    e.printStackTrace();
+                    log.error("Mongo save failed ");
                 } finally {
                     lock.unlock();
-                }
-                mySQLCallRecordBiz.saveCallSuccessRecords(savingCallRecords);
-                if (log.isDebugEnabled()) {
-                    log.debug("MySQL Has Saved CallSuccessRecords:{} Successfully", savingCallRecords.size());
                 }
             }
         }, 60, 10, TimeUnit.SECONDS);

--- a/call-statistics-jpa/src/main/java/org/kaws/autoconfigure/MySQLCallStatisticsAutoConfiguration.java
+++ b/call-statistics-jpa/src/main/java/org/kaws/autoconfigure/MySQLCallStatisticsAutoConfiguration.java
@@ -86,10 +86,10 @@ public class MySQLCallStatisticsAutoConfiguration implements ApplicationContextA
 
         scheduledThreadPoolExecutor.scheduleAtFixedRate(() -> {
             if (!CollectionUtils.isEmpty(mySQLCallRecords)) {
-                MySQLCallRecordBiz mySQLCallRecordBiz = applicationContext.getBean(MySQLCallRecordBiz.class);
-                ArrayList<MySQLCallRecord> savingCallRecords;
-                lock.lock();
                 try {
+                    MySQLCallRecordBiz mySQLCallRecordBiz = applicationContext.getBean(MySQLCallRecordBiz.class);
+                    ArrayList<MySQLCallRecord> savingCallRecords;
+                    lock.lock();
                     savingCallRecords = Lists.newArrayList(mySQLCallRecords);
                     mySQLCallRecords.clear();
                     mySQLCallRecordBiz.saveCallRecords(savingCallRecords);
@@ -97,17 +97,16 @@ public class MySQLCallStatisticsAutoConfiguration implements ApplicationContextA
                         log.debug("MySQL Has Saved CallRecords:{} Successfully", savingCallRecords.size());
                     }
                 } catch (Exception e) {
-                    e.printStackTrace();
-                    log.error("Mongo save failed ");
+                    log.error("Mongo save failed：{} ", e.getMessage());
                 } finally {
                     lock.unlock();
                 }
             }
             if (!CollectionUtils.isEmpty(mySQLCallSuccessRecords)) {
-                MySQLCallRecordBiz mySQLCallRecordBiz = applicationContext.getBean(MySQLCallRecordBiz.class);
-                ArrayList<MySQLCallSuccessRecord> savingCallRecords;
-                lock.lock();
                 try {
+                    MySQLCallRecordBiz mySQLCallRecordBiz = applicationContext.getBean(MySQLCallRecordBiz.class);
+                    ArrayList<MySQLCallSuccessRecord> savingCallRecords;
+                    lock.lock();
                     savingCallRecords = Lists.newArrayList(mySQLCallSuccessRecords);
                     mySQLCallSuccessRecords.clear();
                     mySQLCallRecordBiz.saveCallSuccessRecords(savingCallRecords);
@@ -115,8 +114,7 @@ public class MySQLCallStatisticsAutoConfiguration implements ApplicationContextA
                         log.debug("MySQL Has Saved CallSuccessRecords:{} Successfully", savingCallRecords.size());
                     }
                 } catch (Exception e) {
-                    e.printStackTrace();
-                    log.error("Mongo save failed ");
+                    log.error("Mongo save failed：{} ", e.getMessage());
                 } finally {
                     lock.unlock();
                 }


### PR DESCRIPTION
scheduleAtFixedRate定时调度方法中，默认如果有任务执行异常，则后续任务终止执行，所以需要捕获任务的异常
查看scheduleAtFixedRate的 doc说明如下：
> 创建并执行一个周期性操作，该操作在给定的初始延迟之后首先启用，然后在给定的时间段内启用；也就是说，执行将在initialDelay之后开始，然后是initialDelay+period，然后是initialDelay+2*period，依此类推。**如果任务的任何执行遇到异常，则禁止后续执行**。否则，只能通过取消或终止执行者来终止任务。如果此任务的任何执行时间长于其周期，则后续执行可能会延迟开始，但不会同时执行。